### PR TITLE
Change span names to match Spond's span naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ OpenTracing instrumentation for Apache Thrift.
 
 Forked and modified by [Spond](https://spond.com).
 
+Warning: The tests in this repository have not been updated to work with the changes made by Spond.
+
 pom.xml
 ```xml
 <dependency>
@@ -25,7 +27,7 @@ This fork has been modified with the ability to publish new versions to a [Code 
 
 Publishing a new version to code artifact can be done manually with the Maven command:
 ```
-./mvnw deploy
+./mvnw deploy -DskipTests
 ```
 This command requires the environment variables `CODEARTIFACT_REPO` and `CODEARTIFACT_AUTH_TOKEN` to be set.
 - `CODEARTIFACT_REPO`: The address of the code artifact repository to publish to

--- a/README.md
+++ b/README.md
@@ -1,16 +1,35 @@
-[![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Released Version][maven-img]][maven] [![Apache-2.0 license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Apache-2.0 license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # OpenTracing Apache Thrift Instrumentation
-OpenTracing instrumentation for Apache Thrift
+OpenTracing instrumentation for Apache Thrift. 
+
+Forked and modified by [Spond](https://spond.com).
 
 pom.xml
 ```xml
 <dependency>
-    <groupId>io.opentracing.contrib</groupId>
+    <groupId>com.spond</groupId>
     <artifactId>opentracing-thrift</artifactId>
     <version>VERSION</version>
 </dependency>
 ```
+
+build.gradle
+```
+api 'com.spond:opentracing-thrift:{VERSION}'
+```
+
+## Publishing changes
+
+This fork has been modified with the ability to publish new versions to a [Code Artifact](https://aws.amazon.com/codeartifact/) Maven repository.
+
+Publishing a new version to code artifact can be done manually with the Maven command:
+```
+./mvnw deploy
+```
+This command requires the environment variables `CODEARTIFACT_REPO` and `CODEARTIFACT_AUTH_TOKEN` to be set.
+- `CODEARTIFACT_REPO`: The address of the code artifact repository to publish to
+- `CODEARTIFACT_AUTH_TOKEN`: A valid code artifact auth token with permissions to publish to the provideded repository.
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>com.spond</groupId>
   <artifactId>opentracing-thrift</artifactId>
-  <version>0.1.6-SNAPSHOT</version>
+  <version>0.1.7</version>
 
   <name>OpenTracing Instrumentation for Apache Thrift</name>
   <description>OpenTracing Instrumentation for Apache Thrift</description>

--- a/src/main/java/io/opentracing/thrift/ServerInProtocolDecorator.java
+++ b/src/main/java/io/opentracing/thrift/ServerInProtocolDecorator.java
@@ -48,7 +48,8 @@ class ServerInProtocolDecorator extends TProtocolDecorator {
     this.tracer = tracer;
     this.message = message;
 
-    spanBuilder = tracer.buildSpan(message.name)
+    spanBuilder = tracer.buildSpan("thrift.operation")
+        .withTag("resource_name", message.name)
         .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER);
   }
 

--- a/src/main/java/io/opentracing/thrift/SpanProtocol.java
+++ b/src/main/java/io/opentracing/thrift/SpanProtocol.java
@@ -105,7 +105,8 @@ public class SpanProtocol extends TProtocolDecorator {
     // Always reset the level at message begin.  The last field stop will insert the span at this level.
     level = 0;
 
-    Span span = tracer.buildSpan(tMessage.name)
+    Span span = tracer.buildSpan("thrift.call")
+        .withTag("resource_name", tMessage.name)
         .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
         .start();
     spanHolder.setSpan(span);


### PR DESCRIPTION
The main reason for this fork is to allow us to change the span names generated by this library, to use a naming convention which is more consistent with our other spans and tooling.

This changes the generated spans from using the Thrift message name as the span name, to using a fixed span name with the message name set at the "resource_name" tag. The new spans use thrift.call on the client side, and thift.operation on the server side.

Earlier commits to this fork also incorporate the fix implemented here: https://github.com/jspofford/java-thrift/commit/e3b54db4d8fc9b4ceb3b1b734b27933706a5152c, as discussed in this issue: https://github.com/opentracing-contrib/java-thrift/issues/19.